### PR TITLE
Add file permission step input

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .bitrise*
 _tmp/
+.idea

--- a/bitrise.yml
+++ b/bitrise.yml
@@ -100,6 +100,21 @@ workflows:
                 echo "Does not exist: ~/destination withespace/dir/release.apk"
                 exit 1
             fi
+    - path::./:
+        title: Step Test - File permission
+        inputs:
+        - source: $SOURCE
+        - destination: ./sensitive_file
+        - file_permission: 600
+    - script:
+        title: Check file permission
+        inputs:
+        - content: |-
+            set -ex
+            if [ $(stat -f "%A" ./sensitive_file) != 600 ]; then
+              echo "Downloaded file permission is not 600"
+              exit 1
+            fi
 
   # ----------------------------------------------------------------
   # --- workflows to create Release

--- a/step.sh
+++ b/step.sh
@@ -69,6 +69,7 @@ function print_and_run {
 echo_info "Configs:"
 echo_details "* source: $source"
 echo_details "* destination: $destination"
+echo_details "* file_permission $file_permission"
 
 validate_required_input "source" $source
 validate_required_input "destination" $destination
@@ -88,3 +89,8 @@ destination="$dir/$base"
 
 set -x
 wget "${source}" --output-document="${destination}"
+
+if [ -n "${file_permission}" ] ; then
+	echo_info "Set file permission to ${file_permission}"
+	chmod "${file_permission}" "${destination}"
+fi

--- a/step.yml
+++ b/step.yml
@@ -1,5 +1,5 @@
 title: File Downloader
-summary: Downloads files for your build.
+summary: Download remote files to the build machine.
 description: |-
   The Step downloads selected files from a URL and places it where you want it to. 
   
@@ -31,13 +31,18 @@ run_if: ".IsCI"
 inputs:
 - source:
   opts:
-    title: Download source url
-    description: |
-      Download source url
+    title: Download source URL
+    summary: Download source URL
     is_required: true
 - destination:
   opts:
     title: Download destination path
-    description: |
-      Download destination path
+    summary: Download destination path
     is_required: true
+- file_permission:
+    title: Destination file permission
+    summary: Permission bits for the destination file
+    description: |
+      Permission bits for the destination file in the format of `644`.
+
+      This option is useful for sensitive files that should have a permission like `600`.

--- a/step.yml
+++ b/step.yml
@@ -40,9 +40,10 @@ inputs:
     summary: Download destination path
     is_required: true
 - file_permission:
-    title: Destination file permission
-    summary: Permission bits for the destination file
-    description: |
-      Permission bits for the destination file in the format of `644`.
+    opts:
+      title: Destination file permission
+      summary: Permission bits for the destination file
+      description: |
+        Permission bits for the destination file in the format of `644`.
 
-      This option is useful for sensitive files that should have a permission like `600`.
+        This option is useful for sensitive files that should have a permission like `600`.

--- a/step.yml
+++ b/step.yml
@@ -40,10 +40,10 @@ inputs:
     summary: Download destination path
     is_required: true
 - file_permission:
-    opts:
-      title: Destination file permission
-      summary: Permission bits for the destination file
-      description: |
-        Permission bits for the destination file in the format of `644`.
+  opts:
+    title: Destination file permission
+    summary: Permission bits for the destination file
+    description: |
+      Permission bits for the destination file in the format of `644`.
 
-        This option is useful for sensitive files that should have a permission like `600`.
+      This option is useful for sensitive files that should have a permission like `600`.


### PR DESCRIPTION
<!--
  You are amazing! Thanks for contributing to our Step library!
  Please fill this template with the details of your change.
-->

### Checklist
<!--
  Put an `x` in the boxes that apply. You can also fill these out after
  creating the PR. This is simply a reminder of what we are going to look
  for before merging your code.
-->
- [ ] I've read and followed the [Contribution Guidelines](https://github.com/bitrise-steplib/.github/blob/main/CONTRIBUTING.md)
- [ ] `step.yml` and `README.md` is updated with the changes (if needed)

### Version
<!-- Leave this untouched if you don't know, we'll help -->
Requires a *MINOR* [version update](https://semver.org/)

### Context

When downloading sensitive files, sometimes tools expect the file to have a restricted permission (such as 600). This PR adds the option to define the permission bits of the downloaded fiel.

<!-- Please link the issue that the PR fixes.
Resolves: #GITHUB_ISSUE_ID or https://link_to_the_issue_on_discuss.bitrise.io.
-->

### Changes

- Add new input: `file_permission`
- Set permission with `chmod` if this input is defined

### Investigation details

<!-- Please share any alternative solutions that were considered along with investigation details. -->

### Decisions

<!-- Please list decisions that were made for this change. -->
